### PR TITLE
feat: add `withTitle()` for  custom alert title

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,25 @@ alerts()->set('danger', 'Error message');
 // custom display time - 1 sec (in milliseconds)
 alerts()->set('success', 'Message', 1000);
 ```
+#### Custom Alert Title
+
+With the new method `withTitle()`, you can set a custom title for your alerts.
+
+```php
+// success alert with a custom title
+alerts()->withTitle('Custom Title')->set('success', 'Success message');
+// error alert with a custom title
+alerts()->withTitle('Oops!')->set('danger', 'Error message');
+
+```
+
+You can also configure whether the Custom Alert Title should be reset after each `set()` call by passing a second parameter:
+
+```php
+// success alert with a custom title that will not reset after each set
+alerts()->withTitle('Custom Title', false)->set('success', 'Success Message One');
+alerts()->set('success', 'Success Message Two');
+```
 
 #### Removing alerts
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,7 +1,12 @@
 parameters:
-	ignoreErrors:
-		-
-			message: '#^Call to method PHPUnit\\Framework\\Assert\:\:assertInstanceOf\(\) with ''Michalsn\\\\CodeIgniterHtmxAlerts\\\\Alerts'' and Michalsn\\CodeIgniterHtmxAlerts\\Alerts will always evaluate to true\.$#'
-			identifier: method.alreadyNarrowedType
-			count: 1
-			path: tests/AlertsTest.php
+  ignoreErrors:
+      - message: '#^Call to method PHPUnit\\Framework\\Assert\:\:assertInstanceOf\(\) with ''Michalsn\\\\CodeIgniterHtmxAlerts\\\\Alerts'' and Michalsn\\CodeIgniterHtmxAlerts\\Alerts will always evaluate to true\.$#'
+        identifier: method.alreadyNarrowedType
+        count: 1
+        path: tests/AlertsTest.php
+
+      - message: '#^Call to method PHPUnit\\Framework\\Assert\:\:assertInstanceOf\(\) with ''Michalsn\\\\CodeIgniterHtmxAlerts\\\\Alerts'' and Michalsn\\CodeIgniterHtmxAlerts\\Alerts will always evaluate to true\.$#'
+        identifier: method.alreadyNarrowedType
+        count: 1
+        path: tests/CommonTest.php
+

--- a/src/Alerts.php
+++ b/src/Alerts.php
@@ -11,6 +11,18 @@ class Alerts
 {
     protected array $data = [];
 
+    /**
+     * The current custom title for alerts.
+     * If set to null, the default title will be used.
+     */
+    protected ?string $currentTitle = null;
+
+    /**
+     * Determines whether the title should be reset after each `set()` call.
+     * If set to `true`, the title will be cleared after every `set()`.
+     */
+    protected bool $resetTitleAfterSet = true;
+
     public function __construct(protected AlertsConfig $config, protected Session $session)
     {
     }
@@ -43,6 +55,21 @@ class Alerts
         }
 
         return $this->data[$type] ?? [];
+    }
+
+    /**
+     * Sets a custom title for upcoming alerts.
+     *
+     * @param string $title              The custom title for the alert.
+     * @param bool   $resetTitleAfterSet Determines whether the title should be reset after each `set()` call.
+     *                                   Defaults to `true`, meaning the title will be reset after `set()`.
+     */
+    public function withTitle(string $title, bool $resetTitleAfterSet = true): static
+    {
+        $this->currentTitle       = $title;
+        $this->resetTitleAfterSet = $resetTitleAfterSet;
+
+        return $this;
     }
 
     /**

--- a/src/Alerts.php
+++ b/src/Alerts.php
@@ -38,7 +38,7 @@ class Alerts
         }
 
         $this->data[$type][] = [
-            'title'       => $this->currentTitle,
+            'title'       => $this->currentTitle ?? setting('Alerts.types')[$type],
             'message'     => $message,
             'displayTime' => $displayTime ?? $this->config->displayTime,
         ];

--- a/src/Alerts.php
+++ b/src/Alerts.php
@@ -38,9 +38,14 @@ class Alerts
         }
 
         $this->data[$type][] = [
+            'title'       => $this->currentTitle,
             'message'     => $message,
             'displayTime' => $displayTime ?? $this->config->displayTime,
         ];
+
+        if ($this->resetTitleAfterSet) {
+            $this->currentTitle = null;
+        }
 
         return $this;
     }

--- a/src/Views/display.php
+++ b/src/Views/display.php
@@ -3,7 +3,7 @@
         <div x-data="{ show: true }" x-show="show" x-init="setTimeout(() => show = false, <?= esc($message['displayTime']); ?>)" class="toast show mt-1" role="alert" aria-live="assertive" aria-atomic="true">
             <div class="toast-header">
                 <span class="bg-<?= esc($type, 'attr'); ?> avatar avatar-xs me-2"></span>
-                <strong class="me-auto"><?= esc($message['title'] ?? esc(setting('Alerts.types')[$type]) ?? ''); ?></strong>
+                <strong class="me-auto"><?= esc($message['title']); ?></strong>
                 <button class="btn-close" type="button" data-bs-dismiss="toast" aria-label="Close"></button>
             </div>
             <div class="toast-body text-muted"><?= esc($message['message']); ?></div>

--- a/src/Views/display.php
+++ b/src/Views/display.php
@@ -1,9 +1,9 @@
 <?php foreach ($alerts as $type => $messages): ?>
     <?php foreach ($messages as $message): ?>
-        <div x-data="{ show: true }" x-show="show" x-init="setTimeout(() => show = false, <?= $message['displayTime']; ?>)" class="toast show mt-1" role="alert" aria-live="assertive" aria-atomic="true">
+        <div x-data="{ show: true }" x-show="show" x-init="setTimeout(() => show = false, <?= esc($message['displayTime']); ?>)" class="toast show mt-1" role="alert" aria-live="assertive" aria-atomic="true">
             <div class="toast-header">
                 <span class="bg-<?= esc($type, 'attr'); ?> avatar avatar-xs me-2"></span>
-                <strong class="me-auto"><?= setting('Alerts.types')[$type] ?? ''; ?></strong>
+                <strong class="me-auto"> <?= esc($message['title'] ?? esc(setting('Alerts.types')[$type]) ?? ''); ?></strong>
                 <button class="btn-close" type="button" data-bs-dismiss="toast" aria-label="Close"></button>
             </div>
             <div class="toast-body text-muted"><?= esc($message['message']); ?></div>

--- a/src/Views/display.php
+++ b/src/Views/display.php
@@ -3,7 +3,7 @@
         <div x-data="{ show: true }" x-show="show" x-init="setTimeout(() => show = false, <?= esc($message['displayTime']); ?>)" class="toast show mt-1" role="alert" aria-live="assertive" aria-atomic="true">
             <div class="toast-header">
                 <span class="bg-<?= esc($type, 'attr'); ?> avatar avatar-xs me-2"></span>
-                <strong class="me-auto"> <?= esc($message['title'] ?? esc(setting('Alerts.types')[$type]) ?? ''); ?></strong>
+                <strong class="me-auto"><?= esc($message['title'] ?? esc(setting('Alerts.types')[$type]) ?? ''); ?></strong>
                 <button class="btn-close" type="button" data-bs-dismiss="toast" aria-label="Close"></button>
             </div>
             <div class="toast-body text-muted"><?= esc($message['message']); ?></div>

--- a/src/Views/display.php
+++ b/src/Views/display.php
@@ -1,6 +1,6 @@
 <?php foreach ($alerts as $type => $messages): ?>
     <?php foreach ($messages as $message): ?>
-        <div x-data="{ show: true }" x-show="show" x-init="setTimeout(() => show = false, <?= esc($message['displayTime']); ?>)" class="toast show mt-1" role="alert" aria-live="assertive" aria-atomic="true">
+        <div x-data="{ show: true }" x-show="show" x-init="setTimeout(() => show = false, <?= $message['displayTime']; ?>)" class="toast show mt-1" role="alert" aria-live="assertive" aria-atomic="true">
             <div class="toast-header">
                 <span class="bg-<?= esc($type, 'attr'); ?> avatar avatar-xs me-2"></span>
                 <strong class="me-auto"><?= esc($message['title']); ?></strong>

--- a/tests/AlertsTest.php
+++ b/tests/AlertsTest.php
@@ -4,15 +4,15 @@ declare(strict_types=1);
 
 namespace Tests;
 
-use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\DatabaseTestTrait;
 use Michalsn\CodeIgniterHtmxAlerts\Alerts;
 use Michalsn\CodeIgniterHtmxAlerts\Config\Alerts as AlertsConfig;
+use Tests\Support\TestCase;
 
 /**
  * @internal
  */
-final class AlertsTest extends CIUnitTestCase
+final class AlertsTest extends TestCase
 {
     use DatabaseTestTrait;
 
@@ -247,7 +247,6 @@ final class AlertsTest extends CIUnitTestCase
 
     public function testDisplayAlerts(): void
     {
-        helper('setting');
         $alerts = $this->alertsInstance();
         $output = $alerts->set('success', 'success message')->display();
         $this->assertStringContainsString('toast-header', $output);
@@ -262,7 +261,6 @@ final class AlertsTest extends CIUnitTestCase
 
     public function testInlineAlerts(): void
     {
-        helper('setting');
         $alerts = $this->alertsInstance();
         $output = $alerts->set('success', 'success message')->inline();
         $this->assertStringContainsString('hx-swap-oob="beforeend:#alerts-wrapper"', $output);
@@ -277,11 +275,10 @@ final class AlertsTest extends CIUnitTestCase
 
     public function testSessionAlerts(): void
     {
-        helper('setting');
         $alerts = $this->alertsInstance();
         $alerts->set('success', 'success message')->session();
         $this->assertSame(
-            ['success' => [['message' => 'success message', 'displayTime' => 5000]]],
+            ['success' => [['title' => 'Success', 'message' => 'success message', 'displayTime' => 5000]]],
             service('session')->getFlashdata('alerts'),
         );
     }
@@ -291,6 +288,43 @@ final class AlertsTest extends CIUnitTestCase
         $alerts = $this->alertsInstance();
         $alerts->session();
         $this->assertNull(service('session')->getFlashdata('alerts'));
+    }
+
+    public function testWithTitleSetsTitleForNextAlertOnly()
+    {
+        $alerts = $this->alertsInstance();
+        $alerts->withTitle('Important Error')->set('error', 'An error occurred while processing your request.');
+
+        $alerts = $alerts->get('error');
+
+        $this->assertCount(1, $alerts);
+        $this->assertSame('Important Error', $alerts[0]['title']);
+    }
+
+    public function testWithTitleCanPersistTitleForMultipleAlerts()
+    {
+        $alerts = $this->alertsInstance();
+        $alerts->withTitle('General Warning', false);
+        $alerts->set('success', 'Your capacity is running low.');
+        $alerts->set('error', 'You have a new message.');
+
+        $successAlerts = $alerts->get('success');
+        $errorAlerts   = $alerts->get('error');
+
+        $this->assertSame('General Warning', $successAlerts[0]['title']);
+        $this->assertSame('General Warning', $errorAlerts[0]['title']);
+    }
+
+    public function testWithTitleTitleDoesNotPersistAfterSetByDefault()
+    {
+        $alerts = $this->alertsInstance();
+        $alerts->withTitle('Important Error')->set('error', 'An error occurred while processing your request.');
+        $alerts->set('success', 'Operation completed successfully.');
+
+        $errorAlerts   = $alerts->get('error');
+        $successAlerts = $alerts->get('success');
+        $this->assertSame('Important Error', $errorAlerts[0]['title']);
+        $this->assertSame('Success', $successAlerts[0]['title']);
     }
 
     public function testContainer(): void


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes #123).

-->
**Description**
Added `withTitle()` method with flexible usage

- Allows setting a custom title for alerts.
- Prevents resetting the title by passing `false `as the second parameter, enabling multiple alerts to share the same title.



~I'm working on writing tests for the new `withTitle()` method. If you have any suggestions or improvements, feel free to share your thoughts!~




**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
